### PR TITLE
Optimise perm filter

### DIFF
--- a/algorithm/data/permutations.js
+++ b/algorithm/data/permutations.js
@@ -1,9 +1,7 @@
-import { wordObj, wordObjStrings } from './words.js';
+import { wordsString } from './words.js';
 
 const getPermutations = (hand) => {
-	// console.log('permutations:');
 	const results = [];
-	const MAX_LENGTH = 15;
 
 	// helper function to generate subsets of hand
 	const generateSubsets = (subset, start) => {
@@ -18,7 +16,6 @@ const getPermutations = (hand) => {
 
 	// helper function to generate permutations of the subset
 	const permute = (arr) => {
-		// if (arr.length === 1) return [arr];
 		if (arr.length === 1) {
 			const isJoker = arr[0] === 'j';
 			return [
@@ -66,16 +63,8 @@ const getPermutations = (hand) => {
 			p.string = p.permutation.join('');
 			if (p.jokers === 0) {
 				p.regExp = new RegExp(p.string);
-				for (
-					let length = p.permutation.length;
-					length <= MAX_LENGTH;
-					length++
-				) {
-					const wordsString = wordObjStrings[length];
-					if (wordsString.includes(p.string)) {
-						filteredPermutations.push(p);
-						break;
-					}
+				if (wordsString.includes(p.string)) {
+					filteredPermutations.push(p);
 				}
 			} else {
 				// if there are jokers in permutation
@@ -90,16 +79,8 @@ const getPermutations = (hand) => {
 				}
 				// store regex in permutation object
 				p.regExp = new RegExp(p.string);
-				for (
-					let length = p.permutation.length;
-					length <= MAX_LENGTH;
-					length++
-				) {
-					const wordsString = wordObjStrings[length];
-					if (p.regExp.test(wordsString)) {
-						filteredPermutations.push(p);
-						break;
-					}
+				if (p.regExp.test(wordsString)) {
+					filteredPermutations.push(p);
 				}
 			}
 		}

--- a/algorithm/data/permutations.js
+++ b/algorithm/data/permutations.js
@@ -1,4 +1,4 @@
-import { wordObj } from './words.js';
+import { wordObj, wordObjStrings } from './words.js';
 
 const getPermutations = (hand) => {
 	// console.log('permutations:');
@@ -71,17 +71,11 @@ const getPermutations = (hand) => {
 					length <= MAX_LENGTH;
 					length++
 				) {
-					let isValidPerm = false;
-					const wordArray = wordObj[length];
-					for (const word of wordArray) {
-						if (word.includes(p.string)) {
-							filteredPermutations.push(p);
-							// console.log(p.permutation);
-							isValidPerm = true;
-							break;
-						}
+					const wordsString = wordObjStrings[length];
+					if (wordsString.includes(p.string)) {
+						filteredPermutations.push(p);
+						break;
 					}
-					if (isValidPerm) break;
 				}
 			} else {
 				// if there are jokers in permutation
@@ -101,17 +95,11 @@ const getPermutations = (hand) => {
 					length <= MAX_LENGTH;
 					length++
 				) {
-					let isValidPerm = false;
-					const wordArray = wordObj[length];
-					for (const word of wordArray) {
-						if (p.regExp.test(word)) {
-							filteredPermutations.push(p);
-							// console.log(p.permutation);
-							isValidPerm = true;
-							break;
-						}
+					const wordsString = wordObjStrings[length];
+					if (p.regExp.test(wordsString)) {
+						filteredPermutations.push(p);
+						break;
 					}
-					if (isValidPerm) break;
 				}
 			}
 		}

--- a/algorithm/data/words.js
+++ b/algorithm/data/words.js
@@ -8,6 +8,12 @@ const wordArray = fs
 	.split('\n')
 	.sort((a, b) => a.length - b.length);
 
+let wordsString = '';
+for (const word of wordArray) {
+	if (word.length > 15) break;
+	wordsString += ` ${word}`;
+}
+
 const wordObj = {};
 for (const word of wordArray) {
 	if (word.length >= 16) break;
@@ -44,4 +50,4 @@ for (const word of wordArray) {
 // 	'utf8'
 // );
 
-export { wordArray, wordObj, wordArraySplit, wordObjStrings };
+export { wordArray, wordObj, wordArraySplit, wordObjStrings, wordsString };

--- a/algorithm/data/words.js
+++ b/algorithm/data/words.js
@@ -17,6 +17,15 @@ for (const word of wordArray) {
 	wordObj[word.length].push(word);
 }
 
+const wordObjStrings = {};
+for (const word of wordArray) {
+	if (word.length >= 16) break;
+	if (!wordObjStrings[word.length]) {
+		wordObjStrings[word.length] = '';
+	}
+	wordObjStrings[word.length] += ` ${word}`;
+}
+
 const wordArraySplit = [[]];
 for (const word of wordArray) {
 	if (!wordArraySplit[word.length]) {
@@ -35,4 +44,4 @@ for (const word of wordArray) {
 // 	'utf8'
 // );
 
-export { wordArray, wordObj, wordArraySplit };
+export { wordArray, wordObj, wordArraySplit, wordObjStrings };


### PR DESCRIPTION
- Replaced looping through array of words of a certain length with running a single includes or regExp.test on a single string that has all words 15 chars or less in it
- Dramatically reduced cpu time for filtering permutations for joker and non joker hands